### PR TITLE
no push

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -2,7 +2,6 @@ name: ci-tests
 
 on:
   pull_request:
-  push:
 
 permissions:
   contents: read

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -1,7 +1,6 @@
 name: UI Tests
 
 on:
-  push:
   pull_request:
 
 concurrency:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow triggers to simplify when CI and UI tests are run. The main change is that both workflows will now only run on pull requests, not on every push.

Workflow trigger updates:

* [`.github/workflows/ci-tests.yml`](diffhunk://#diff-03609cb60b0c6e92fb771eb8787d6722b8c31ca4c03eabc788e147acd8c6fb43L5): Removed the `push` event trigger so that CI tests only run when a pull request is opened or updated.
* [`.github/workflows/ui-tests.yml`](diffhunk://#diff-25db25f7c22b5c3caa8492dd43c3d54f3ba1bd5758cf9922b74ab402633a381bL4): Removed the `push` event trigger so that UI tests only run on pull requests.