### PR TITLE
rename workflows

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,4 +1,4 @@
-name: ci-tests
+name: CI Tests
 
 on:
   pull_request:

--- a/.github/workflows/rss-github-page.yml
+++ b/.github/workflows/rss-github-page.yml
@@ -1,4 +1,4 @@
-name: RSS News Dashboard
+name: DevOps Feed Hub
 
 on:
   push:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,4 +1,4 @@
-name: Super-Linter
+name: Superlinter
 
 on:
   pull_request:


### PR DESCRIPTION
This pull request updates the names of several GitHub Actions workflows to improve clarity and consistency across the CI/CD pipeline.

Workflow name updates:

* [`.github/workflows/ci-tests.yml`](diffhunk://#diff-03609cb60b0c6e92fb771eb8787d6722b8c31ca4c03eabc788e147acd8c6fb43L1-R1): Changed workflow name from "ci-tests" to "CI Tests" for improved readability.
* [`.github/workflows/rss-github-page.yml`](diffhunk://#diff-0d36fd7fa9fe06dec3c543dc74999317c84a134bc0c7f4038bf9e1ec10d1bb56L1-R1): Renamed workflow from "RSS News Dashboard" to "DevOps Feed Hub" to better reflect its purpose.
* [`.github/workflows/super-linter.yml`](diffhunk://#diff-3336387af05d3a6efeaa358d145494d23b6036f9034efe8ff6edca2522f06c33L1-R1): Updated workflow name from "Super-Linter" to "Superlinter" for naming consistency.