### PR TITLE
Change workflow name to lowercase format

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,4 +1,4 @@
-name: "Copilot Setup Steps"
+name: "Copilot setup steps"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
This pull request includes a minor update to the workflow configuration file. The only change is a small adjustment to the workflow's display name for consistency in capitalization.