### PR TITLE
add feeds

### DIFF
--- a/.github/rss-feeds.json
+++ b/.github/rss-feeds.json
@@ -13,8 +13,12 @@
       "url": "https://techcommunity.microsoft.com/t5/s/gxcuf89792/rss/board?board.id=microsoft-entra-blog"
     },
     {
+      "name": "Microsoft Azure Blog",
+      "url": "https://azurecomcdn.azureedge.net/en-us/blog/feed/"
+    },
+    {
       "name": "Azure Updates",
-      "url": "https://aztty.azurewebsites.net/rss/updates?service=40"
+      "url": "https://www.microsoft.com/releasecommunications/api/v2/azure/rss"
     },
     {
       "name": "GitHub Changelog",
@@ -42,11 +46,11 @@
     },
     {
       "name": "GitLab Blog",
-      "url": "https://about.gitlab.com/blog/categories/releases/feed.xml"
+      "url": "https://about.gitlab.com/atom.xml"
     },
     {
       "name": "Jenkins Blog",
-      "url": "https://www.jenkins.io/node/feed.xml"
+      "url": "https://feeds.feedburner.com/ContinuousBlog"
     },
     {
       "name": "Red Hat Developer",
@@ -59,6 +63,14 @@
     {
       "name": "Atlassian DevOps",
       "url": "https://www.atlassian.com/blog/devops/feed"
+    },
+    {
+      "name": "Opensource.com",
+      "url": "https://opensource.com/feed"
+    },
+    {
+      "name": "Terraform weekly",
+      "url": "https://rss.beehiiv.com/feeds/4FnlUFPRgf.xml"
     }
   ]
 }


### PR DESCRIPTION
This pull request updates the `.github/rss-feeds.json` file to improve and expand the list of RSS feeds used by the project. The main changes include adding new feeds and updating the URLs of several existing feeds to more current or comprehensive sources.

**Feed additions:**
* Added the "Microsoft Azure Blog" RSS feed to expand coverage of Azure-related updates.
* Added the "Opensource.com" and "Terraform weekly" RSS feeds to include more open source and infrastructure-as-code content.

**Feed updates:**
* Updated the "Azure Updates" RSS feed URL to use the official Microsoft release communications endpoint for more reliable updates.
* Changed the "GitLab Blog" feed to use the main Atom feed, ensuring broader coverage of posts.
* Updated the "Jenkins Blog" feed to use the Feedburner URL, which is more actively maintained.