### PR TITLE
Refactor/push main

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,6 +1,9 @@
 name: CI Tests
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
 
 permissions:

--- a/.github/workflows/rss-github-page.yml
+++ b/.github/workflows/rss-github-page.yml
@@ -2,7 +2,7 @@ name: DevOps Feed Hub
 
 on:
   push:
-
+  
   schedule:
     - cron: "0 */12 * * *"
 

--- a/.github/workflows/rss-github-page.yml
+++ b/.github/workflows/rss-github-page.yml
@@ -2,7 +2,7 @@ name: DevOps Feed Hub
 
 on:
   push:
-  
+
   schedule:
     - cron: "0 */12 * * *"
 

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -1,6 +1,9 @@
 name: UI Tests
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
 
 concurrency:


### PR DESCRIPTION
This pull request updates the CI and UI test workflows to ensure tests are automatically run on pushes to the `main` branch, not just on pull requests. This helps catch issues earlier and ensures the main branch remains stable.

Workflow trigger improvements:

* [`.github/workflows/ci-tests.yml`](diffhunk://#diff-03609cb60b0c6e92fb771eb8787d6722b8c31ca4c03eabc788e147acd8c6fb43R4-R6): Added `push` trigger for the `main` branch so CI tests run on every push to `main`.
* [`.github/workflows/ui-tests.yml`](diffhunk://#diff-25db25f7c22b5c3caa8492dd43c3d54f3ba1bd5758cf9922b74ab402633a381bR4-R6): Added `push` trigger for the `main` branch so UI tests run on every push to `main`.